### PR TITLE
プロジェクトをとりあえずDockerrize

### DIFF
--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -1,0 +1,17 @@
+services:
+  nginx:
+    image: nginx:1.21.1
+    ports:
+      - "80:80"
+    volumes:
+      - ./docker/nginx/default.conf:/etc/nginx/conf.d/default.conf
+      - .:/var/www/html
+    depends_on:
+      - php
+
+  php:
+    build:
+      context: .
+      dockerfile: ./docker/php/Dockerfile
+    volumes:
+      - .:/var/www/html

--- a/docker/nginx/default.conf
+++ b/docker/nginx/default.conf
@@ -1,0 +1,20 @@
+server {
+    listen 80;
+    index index.php index.html;
+    server_name localhost;
+
+    root /var/www/html;
+
+    location / {
+        try_files $uri $uri/ /index.php$is_args$args;
+    }
+
+    location ~ \.php$ {
+        fastcgi_split_path_info ^(.+\.php)(/.+)$;
+        fastcgi_pass php:9000;
+        fastcgi_index index.php;
+        include fastcgi_params;
+        fastcgi_param SCRIPT_FILENAME $document_root$fastcgi_script_name;
+        fastcgi_param PATH_INFO $fastcgi_path_info;
+    }
+}

--- a/docker/php/Dockerfile
+++ b/docker/php/Dockerfile
@@ -1,0 +1,16 @@
+FROM php:5.6-fpm
+
+RUN sed -i '/deb.debian.org\/debian stretch/d' /etc/apt/sources.list
+RUN sed -i '/security.debian.org\/debian-security stretch\/updates/d' /etc/apt/sources.list
+RUN echo "deb http://archive.debian.org/debian/ stretch main" >> /etc/apt/sources.list
+RUN echo "deb http://archive.debian.org/debian-security/ stretch/updates main" >> /etc/apt/sources.list
+RUN echo "Acquire::Check-Valid-Until false;" > /etc/apt/apt.conf.d/99disablechecks
+
+COPY ./docker/php/php.ini /usr/local/etc/php/
+
+RUN set -xe; \
+    apt-get update -yqq && \
+    apt-get install -yqq \
+    curl
+
+WORKDIR /var/www

--- a/docker/php/php.ini
+++ b/docker/php/php.ini
@@ -1,0 +1,5 @@
+date.timezone = "Asia/Tokyo"
+
+[mbstring]
+mbstring.internal_encoding = "UTF-8"
+mbstring.language = "Japanese"


### PR DESCRIPTION
## チケット
#1  

## やったこと
###  箱庭諸島をDockerrizeしてローカルで動かせるように
- とりあえず、Dockerfileのビルドとコンテナの起動ができるように。
  - 古いPHPバージョンのコンテナイメージを利用するため、sedコマンドを使って、/etc/apt/sources.listファイルからdeb.debian.org/debian stretchなどの、サポート終了したDebian Stretchリポジトリへの参照を削除。でないと`apt-get update`が失敗する。

Close #1 